### PR TITLE
Bug fixed // new maxlength input prop

### DIFF
--- a/src/components/HandlePaste.ts
+++ b/src/components/HandlePaste.ts
@@ -46,6 +46,21 @@ const HandlePaste = (
         }
       }
     } else {
+      if (!allowDuplicates) {
+        const existingItems = tagsData.map((t) => t.name);
+        const newSet = items.filter(
+          (item) => existingItems.includes(item) === false
+          );
+        if(newSet.length == 0 )
+        {
+          return {
+            existingItems,
+            tagsCreated: 0
+          }
+        }
+      }
+
+
       const newData = tagsData.concat({
         name: pasteData,
         value: pasteData,

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -24,6 +24,7 @@
           ref="textInputRef"
           v-model="input"
           type="text"
+          :maxlength="maxlengthInput"
           :placeholder="inputPlaceholder"
           @keyup.enter="handleAddTag($event.target.value.trim())"
           @keyup.delete="handleDelete"
@@ -135,6 +136,10 @@ export default defineComponent({
         tagTextColor: "#fff",
       }),
     },
+    maxlengthInput:{
+      type: Number,
+      default: -1,
+    }
   },
   setup: MainSetup,
 });

--- a/src/components/MainSetup.ts
+++ b/src/components/MainSetup.ts
@@ -106,6 +106,10 @@ export default function ({ autosuggest, allowPaste = { delimiter: "," }, allowDu
 
   // handler to add a new tag
   const handleAddTag: (name: string) => void = (name) => {
+    if(name == '')
+    {
+      return
+    }
     let nameToUse = '';
     const selIndex = unref(selectedIndex);
 


### PR DESCRIPTION
Bug Fixed:

 - If enter blank text, the tag counter increase. So if you have maxtag set to 20 , will be limited to 19 and don't allow entering one more. 
 - Copy/paste only one element, don't check duplicated. 

Feature:
- Add max length input prop if user want to add this setting. 